### PR TITLE
Updated bcrypt to bcrypt-nodejs

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -9,7 +9,7 @@ var sessionManager = require('ep_etherpad-lite/node/db/SessionManager');
 var crypto = require('crypto');
 
 // npm install bcrypt
-var bcrypt = require('bcrypt');
+var bcrypt = require('bcrypt-nodejs');
 
 // ocrypt-relevant options
 var hash_typ = "sha512";

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "log4js": ">= 0.5.x",
         "regexp-quote": "*",
         "mime": ">= 1.2.11",
-        "bcrypt": "*"
+        "bcrypt-nodejs": "*"
     },
     "devDependencies": {},
     "optionalDependencies": {},

--- a/publish.sh
+++ b/publish.sh
@@ -50,7 +50,7 @@ echo '{
         "log4js": ">= 0.5.x",
         "regexp-quote": "*",
         "mime": ">= 1.2.11",
-        "bcrypt": "*"
+        "bcrypt-nodejs": "*"
     },
     "devDependencies": {},
     "optionalDependencies": {},


### PR DESCRIPTION
I appreciate this repo + plugin are "archived" but as they are still appearing on the etherpad plugin list I think they're worth keeping semi-updated so the next person who tried to install doesn't have as much trouble as I did.

The old bcrypt dependency is throwing errors and failing to install in etherpad. Simply updating a few bcrypt dependencies to use bcrypt-nodejs instead solves the problem and allows the plugin to be installed with etherpad 1.7.5